### PR TITLE
[jenkins] install boost in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,36 +7,18 @@ RUN pip install -r /src/$APPNAME/requirements.txt
 
 RUN apt-get install -y libgsl-dev || yum install -y gsl-devel
 
-ENV BOOST_VERSION=1.72.0 BOOST_ROOT=/opt/boost
-ADD https://github.com/boostorg/boost/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-boost.tar.gz
-ADD https://github.com/boostorg/build/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-build.tar.gz
-ADD https://github.com/boostorg/config/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-config.tar.gz
-ADD https://github.com/boostorg/boost_install/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-boost_install.tar.gz
-ADD https://github.com/boostorg/headers/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-headers.tar.gz
-ADD https://github.com/boostorg/core/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-core.tar.gz
-ADD https://github.com/boostorg/serialization/archive/boost-$BOOST_VERSION.tar.gz /tmp/boost-serialization.tar.gz
-RUN chown build /tmp/boost-*.tar.gz
+ENV BOOST_ROOT=/opt/boost
+ADD https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz /tmp/boost.tar.gz
+RUN chown build /tmp/boost.tar.gz
 USER build
-RUN mkdir -p /tmp/boost && \
-    cd /tmp/boost && \
-    for c in \
-      boost:. \
-      build:tools/build \
-      config:libs/config \
-      boost_install:tools/boost_install \
-      headers:libs/headers \
-      core:libs/core \
-      serialization:libs/serialization \
-    ; do \
-      # https://github.com/boostorg/${c%:*}/archive/boost-$BOOST_VERSION.tar.gz
-      tar -C ${c#*:} --strip-components=1 -xf /tmp/boost-${c%:*}.tar.gz && rm /tmp/boost-${c%:*}.tar.gz ; \
-    done && \
+RUN tar -C /tmp -xf /tmp/boost.tar.gz && \
+    cd /tmp/boost_* && \
     case $CC in (clang*) toolset=clang ;; (gcc*) toolset=gcc ;; esac ; \
     ./bootstrap.sh --prefix=$BOOST_ROOT --with-toolset=$toolset --with-libraries=serialization && \
     ./b2 ${CXXFLAGS:+cxxflags=$CXXFLAGS linkflags=$CXXFLAGS}
 USER root
-RUN cd /tmp/boost && ./b2 install && \
-    cd / && rm -rf /tmp/boost
+RUN cd /tmp/boost_* && ./b2 install && \
+    cd / && rm -rf /tmp/boost*
 
 COPY . $SRC/$APPNAME
 WORKDIR $BUILD/$APPNAME


### PR DESCRIPTION
This adds a boost serialization build step to the CI for Ubuntu builds.
This is to avoid any `libc++` vs `libstdc++` problems.

@dylex Thank you for the work!